### PR TITLE
Reflect WordPress new minimum PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "url": "https://wordpress.org/nightly-builds/wordpress-latest.zip"
     },
     "require": {
-        "php": ">= 7.0.0"
+        "php": ">= 7.2.24"
     },
     "provide": {
         "wordpress/core-implementation": "dev-nightly"


### PR DESCRIPTION
https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/

This got missed last year.

Previously: 3ba591cba9dad2a5cedcddb12b0bd7f3f8a9f7af
